### PR TITLE
Add several "vagrant commands" to help control OSUMO plugin from host

### DIFF
--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -33,3 +33,39 @@ class GirderRestart < Vagrant.plugin("2")
     GirderRestartCmd
   end
 end
+
+class GirderWorkerLogCmd < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "shows running Girder Worker log on the guest"
+  end
+
+  def execute
+    exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
+  end
+end
+
+class Log < Vagrant.plugin("2")
+  name "Girder Worker Log"
+
+  command "girder-worker-log" do
+    GirderWorkerLogCmd
+  end
+end
+
+class GirderWorkerRestartCmd < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "restarts GirderWorker"
+  end
+
+  def execute
+    exec("vagrant ssh -c 'sudo restart girder-worker'")
+  end
+end
+
+class GirderWorkerRestart < Vagrant.plugin("2")
+  name "Girder Worker Restart"
+
+  command "girder-worker-restart" do
+    GirderWorkerRestartCmd
+  end
+end

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -69,3 +69,21 @@ class GirderWorkerRestart < Vagrant.plugin("2")
     GirderWorkerRestartCmd
   end
 end
+
+class WatchCmd < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "builds OSUMO plugin in watch mode"
+  end
+
+  def execute
+    exec("vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")
+  end
+end
+
+class Watch < Vagrant.plugin(2)
+  name "Build OSUMO in watch mode"
+
+  command "watch" do
+    WatchCmd
+  end
+end

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,28 +1,16 @@
-class GirderLogCmd < Vagrant.plugin(2, :command)
-  def self.synopsis
-    "shows running Girder log on the guest"
-  end
-
-  def execute
-    exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
-  end
-end
-
 class Log < Vagrant.plugin("2")
   name "Girder Log"
 
   command "girder-log" do
-    GirderLogCmd
-  end
-end
+    Class.new(Vagrant.plugin(2, :command)) do
+      def self.synopsis
+        "shows running Girder log on the guest"
+      end
 
-class GirderRestartCmd < Vagrant.plugin(2, :command)
-  def self.synopsis
-    "restarts Girder"
-  end
-
-  def execute
-    exec("vagrant ssh -c 'sudo restart girder'")
+      def execute
+        exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
+      end
+    end
   end
 end
 
@@ -30,17 +18,15 @@ class GirderRestart < Vagrant.plugin("2")
   name "Girder Restart"
 
   command "girder-restart" do
-    GirderRestartCmd
-  end
-end
+    Class.new(Vagrant.plugin(2, :command)) do
+      def self.synopsis
+        "restarts Girder"
+      end
 
-class GirderWorkerLogCmd < Vagrant.plugin(2, :command)
-  def self.synopsis
-    "shows running Girder Worker log on the guest"
-  end
-
-  def execute
-    exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
+      def execute
+        exec("vagrant ssh -c 'sudo restart girder'")
+      end
+    end
   end
 end
 
@@ -48,17 +34,15 @@ class Log < Vagrant.plugin("2")
   name "Girder Worker Log"
 
   command "girder-worker-log" do
-    GirderWorkerLogCmd
-  end
-end
+    Class.new(Vagrant.plugin(2, :command)) do
+      def self.synopsis
+        "shows running Girder Worker log on the guest"
+      end
 
-class GirderWorkerRestartCmd < Vagrant.plugin(2, :command)
-  def self.synopsis
-    "restarts GirderWorker"
-  end
-
-  def execute
-    exec("vagrant ssh -c 'sudo restart girder-worker'")
+      def execute
+        exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
+      end
+    end
   end
 end
 
@@ -66,17 +50,15 @@ class GirderWorkerRestart < Vagrant.plugin("2")
   name "Girder Worker Restart"
 
   command "girder-worker-restart" do
-    GirderWorkerRestartCmd
-  end
-end
+    Class.new(Vagrant.plugin(2, :command)) do
+      def self.synopsis
+        "restarts GirderWorker"
+      end
 
-class WatchCmd < Vagrant.plugin(2, :command)
-  def self.synopsis
-    "builds OSUMO plugin in watch mode"
-  end
-
-  def execute
-    exec("vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")
+      def execute
+        exec("vagrant ssh -c 'sudo restart girder-worker'")
+      end
+    end
   end
 end
 
@@ -84,6 +66,14 @@ class Watch < Vagrant.plugin(2)
   name "Build OSUMO in watch mode"
 
   command "watch" do
-    WatchCmd
+    Class.new(Vagrant.plugin(2, :command)) do
+      def self.synopsis
+        "builds OSUMO plugin in watch mode"
+      end
+
+      def execute
+        exec("vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")
+      end
+    end
   end
 end

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -22,8 +22,11 @@ def vagrant_command(name, synopsis, command)
   command(name, synopsis, "vagrant ssh -c '#{command}'")
 end
 
+# Capture the first argument to the command for use by the "service" commands.
+service_command = ARGV[1] || "status"
+
 vagrant_command("osumo-girder-log", "tails Girder log", "sudo tail -c +1 -f /var/log/upstart/girder.log")
-vagrant_command("osumo-girder-restart", "restarts Girder", "sudo restart girder")
-vagrant_command("osumo-girder-worker-log", "tails Girder Worker log", "sudo tail -c +1 -f /var/log/upstart/girder-worker.log")
-vagrant_command("osumo-girder-worker-restart", "restarts Girder Worker", "sudo restart girder-worker")
+vagrant_command("osumo-girder-service", "restarts Girder", "sudo #{service_command} girder")
+vagrant_command("osumo-gw-log", "tails Girder Worker log", "sudo tail -c +1 -f /var/log/upstart/girder-worker.log")
+vagrant_command("osumo-gw-service", "restarts Girder Worker", "sudo #{service_command} girder-worker")
 vagrant_command("osumo-watch", "builds OSUMO plugin in watch mode", "./venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index")

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -25,8 +25,8 @@ end
 # Capture the first argument to the command for use by the "service" commands.
 service_command = ARGV[1] || "status"
 
-vagrant_command("osumo-girder-log", "tails Girder log", "sudo tail -c +1 -f /var/log/upstart/girder.log")
+vagrant_command("osumo-girder-log", "tails Girder log", "sudo tail -c +1 -F /var/log/upstart/girder.log")
 vagrant_command("osumo-girder-service", "restarts Girder", "sudo #{service_command} girder")
-vagrant_command("osumo-gw-log", "tails Girder Worker log", "sudo tail -c +1 -f /var/log/upstart/girder-worker.log")
+vagrant_command("osumo-gw-log", "tails Girder Worker log", "sudo tail -c +1 -F /var/log/upstart/girder-worker.log")
 vagrant_command("osumo-gw-service", "restarts Girder Worker", "sudo #{service_command} girder-worker")
 vagrant_command("osumo-watch", "builds OSUMO plugin in watch mode", "./venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index")

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,79 +1,25 @@
-class Log < Vagrant.plugin("2")
-  name "Girder Log"
+def command(name, synopsis, command)
+  Class.new(Vagrant.plugin("2")) do
+    name name
 
-  command "girder-log" do
-    Class.new(Vagrant.plugin(2, :command)) do
-      def self.synopsis
-        "shows running Girder log on the guest"
-      end
+    command name do
+      Class.new(Vagrant.plugin(2, :command)) do
+        @synopsis = synopsis
 
-      def execute
-        exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
-      end
-    end
-  end
-end
+        def self.synopsis
+          @synopsis
+        end
 
-class GirderRestart < Vagrant.plugin("2")
-  name "Girder Restart"
-
-  command "girder-restart" do
-    Class.new(Vagrant.plugin(2, :command)) do
-      def self.synopsis
-        "restarts Girder"
-      end
-
-      def execute
-        exec("vagrant ssh -c 'sudo restart girder'")
+        define_method :execute do
+          exec(command)
+        end
       end
     end
   end
 end
 
-class Log < Vagrant.plugin("2")
-  name "Girder Worker Log"
-
-  command "girder-worker-log" do
-    Class.new(Vagrant.plugin(2, :command)) do
-      def self.synopsis
-        "shows running Girder Worker log on the guest"
-      end
-
-      def execute
-        exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
-      end
-    end
-  end
-end
-
-class GirderWorkerRestart < Vagrant.plugin("2")
-  name "Girder Worker Restart"
-
-  command "girder-worker-restart" do
-    Class.new(Vagrant.plugin(2, :command)) do
-      def self.synopsis
-        "restarts GirderWorker"
-      end
-
-      def execute
-        exec("vagrant ssh -c 'sudo restart girder-worker'")
-      end
-    end
-  end
-end
-
-class Watch < Vagrant.plugin(2)
-  name "Build OSUMO in watch mode"
-
-  command "watch" do
-    Class.new(Vagrant.plugin(2, :command)) do
-      def self.synopsis
-        "builds OSUMO plugin in watch mode"
-      end
-
-      def execute
-        exec("vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")
-      end
-    end
-  end
-end
+command("girder-log", "tails Girder log", "vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
+command("girder-restart", "restarts Girder", "vagrant ssh -c 'sudo restart girder'")
+command("girder-worker-log", "tails Girder Worker log", "vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
+command("girder-worker-restart", "restarts Girder Worker", "vagrant ssh -c 'sudo restart girder-worker'")
+command("watch", "builds OSUMO plugin in watch mode", "vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,4 +1,4 @@
-class LogCommand < Vagrant.plugin(2, :command)
+class GirderLogCmd < Vagrant.plugin(2, :command)
   def self.synopsis
     "shows running Girder log on the guest"
   end
@@ -11,7 +11,25 @@ end
 class Log < Vagrant.plugin("2")
   name "Girder Log"
 
-  command "girderlog" do
-    LogCommand
+  command "girder-log" do
+    GirderLogCmd
+  end
+end
+
+class GirderRestartCmd < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "restarts Girder"
+  end
+
+  def execute
+    exec("vagrant ssh -c 'sudo restart girder'")
+  end
+end
+
+class GirderRestart < Vagrant.plugin("2")
+  name "Girder Restart"
+
+  command "girder-restart" do
+    GirderRestartCmd
   end
 end

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -18,8 +18,12 @@ def command(name, synopsis, command)
   end
 end
 
-command("girder-log", "tails Girder log", "vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
-command("girder-restart", "restarts Girder", "vagrant ssh -c 'sudo restart girder'")
-command("girder-worker-log", "tails Girder Worker log", "vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder-worker.log'")
-command("girder-worker-restart", "restarts Girder Worker", "vagrant ssh -c 'sudo restart girder-worker'")
-command("watch", "builds OSUMO plugin in watch mode", "vagrant ssh -c './venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index'")
+def vagrant_command(name, synopsis, command)
+  command(name, synopsis, "vagrant ssh -c '#{command}'")
+end
+
+vagrant_command("osumo-girder-log", "tails Girder log", "sudo tail -c +1 -f /var/log/upstart/girder.log")
+vagrant_command("osumo-girder-restart", "restarts Girder", "sudo restart girder")
+vagrant_command("osumo-girder-worker-log", "tails Girder Worker log", "sudo tail -c +1 -f /var/log/upstart/girder-worker.log")
+vagrant_command("osumo-girder-worker-restart", "restarts Girder Worker", "sudo restart girder-worker")
+vagrant_command("osumo-watch", "builds OSUMO plugin in watch mode", "./venv/bin/girder-install web --watch-plugin osumo --plugin-prefix index")

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -1,0 +1,17 @@
+class LogCommand < Vagrant.plugin(2, :command)
+  def self.synopsis
+    "shows running Girder log on the guest"
+  end
+
+  def execute
+    exec("vagrant ssh -c 'tail -c +1 -f .girder/logs/error.log'")
+  end
+end
+
+class Log < Vagrant.plugin("2")
+  name "Girder Log"
+
+  command "girderlog" do
+    LogCommand
+  end
+end

--- a/.vagrantplugins
+++ b/.vagrantplugins
@@ -4,7 +4,7 @@ class GirderLogCmd < Vagrant.plugin(2, :command)
   end
 
   def execute
-    exec("vagrant ssh -c 'tail -c +1 -f .girder/logs/error.log'")
+    exec("vagrant ssh -c 'sudo tail -c +1 -f /var/log/upstart/girder.log'")
   end
 end
 


### PR DESCRIPTION
To see what commands are available, say `vagrant list-commands` at the top level, and look for the commands prefixed with `osumo-`.

Command implementation can be found in `.vagrantplugins`.

Depends on #6 

Closes #5 and #3